### PR TITLE
Fix (#1)

### DIFF
--- a/src/handle_msg.c
+++ b/src/handle_msg.c
@@ -76,8 +76,7 @@ void parse_msg(char* buf, message* msg, int sock_fd) {
 
     char tags[501], message_header[110], message_text[501];
     
-    printf("%s\n", buf);
-    sscanf(buf, "%[^:]:%[^:]:%[^\r\n]", tags, message_header, message_text);
+    sscanf(buf, "%s :%[^:]:%[^\r\n]", tags, message_header, message_text);
     /* printf("%s\n", tags); */
     if (strcmp(tags, PING) == 0) {
         /* puts("Found PING...sending PONG"); */


### PR DESCRIPTION
To find the end of the tags list, we only need to read until the first
whitespace. This is done automatically with %s in sscanf.