### PR TITLE
Fix partial message handling (#5)

### DIFF
--- a/src/handle_msg.h
+++ b/src/handle_msg.h
@@ -18,7 +18,9 @@ int reply_PONG(int sock_fd);
 int send_msg(int sock_fd, char* chan, char* msg);
 
 // Parsing functions
-void parse_msg(char* buf, message* msg, int sock_fd);
+ssize_t find_full_msg(char* buf, ssize_t buf_bytes, message* msg, int sock_fd);
+void flush_msg(char** buf, ssize_t* buf_bytes, ssize_t pos_full_msg, message* msg, int sock_fd);
+void parse_msg(char* buf, ssize_t buf_bytes, message* msg, int sock_fd);
 int parse_tags(char* tags, message* msg);
 int parse_command(int sock_fd, char* chan, char* msg, char* usr);
 int parse_tag_field_value(char* field, char* value, message* msg);


### PR DESCRIPTION
Rework the handling of messages in order to properly handle partial
messages i.e., keep calling recv() until we build a full message and
then parse it. Anything left over becomes a new partial message.